### PR TITLE
Fix authentication bypass for admin interface

### DIFF
--- a/admin_webinterface.py
+++ b/admin_webinterface.py
@@ -195,7 +195,7 @@ def application(env, start_response):
     
     urls = [
         (r'^$', user_interface),
-        (r'admin/?$', admin_interface)
+        (r'^admin/?$', admin_interface)
     ]
 
     path = env.get('PATH_INFO', '').lstrip('/')


### PR DESCRIPTION
Previously, one could access /quota/XXXadmin and was not prompted for a password.
